### PR TITLE
Gui fix

### DIFF
--- a/ext/gui_2D.jl
+++ b/ext/gui_2D.jl
@@ -64,7 +64,7 @@ Keyword (optional) arguments:
 function Makie.plot!(fig::Union{Makie.Figure,Makie.GridPosition}, res::NMRInversions.inv_out_2D;
                      title=res.title, colormap=:viridis, contf=false, levels = 40, 
                      labelsizes = (23, 23), ticksizes = (15, 15), titlesize = 17, titlefont = :bold ,
-                     legendlabelsize = 12
+                     legendlabelsize = 12, gap = 0,
                      )
 
     xlbl = if res.seq == IRCPMG
@@ -77,21 +77,30 @@ function Makie.plot!(fig::Union{Makie.Figure,Makie.GridPosition}, res::NMRInvers
         L"T_2 \,\textrm{(s)}"
     end
 
+    gr = fig[1:10, 1:10] = GridLayout()
+
     # order is important, dont change
     axmain = Axis(
-        fig[3:10, 1:8],
+        gr[3:10, 1:8],
         xlabel=xlbl, ylabel=ylbl,
         xlabelsize=labelsizes[1], ylabelsize=labelsizes[2],
         xticklabelsize=ticksizes[1], yticklabelsize=ticksizes[2],
         xtickalign = 0, ytickalign = 0,
         xscale = log10, yscale = log10
     )
-    axtop = Axis(fig[1:2, 1:8], xscale = log10,
+    axtop = Axis(gr[1:2, 1:8], xscale = log10,
                  title=title, titlesize=titlesize, titlefont=titlefont)
-    axright = Axis(fig[3:10, 9:10], yscale = log10)
+    axright = Axis(gr[3:10, 9:10], yscale = log10)
 
     hidedecorations!(axtop)
     hidedecorations!(axright)
+
+    colgap!(gr , gap)
+    rowgap!(gr , gap)
+    if gap <= 3
+        hidespines!(axtop, :b)
+        hidespines!(axright, :l)
+    end
 
     Makie.deactivate_interaction!(axmain, :rectanglezoom) # Disable zoom
     Makie.deactivate_interaction!(axright, :rectanglezoom) # Disable zoom

--- a/ext/gui_2D.jl
+++ b/ext/gui_2D.jl
@@ -60,6 +60,8 @@ Keyword (optional) arguments:
 - `ticksizes` : Size of the axis ticks (default: (14, 14)).
 - `titlesize` : Size of the title (default: 17).
 - `titlefont` : Font of the title (default: :bold).
+- `legendlabelsize` : Size of the legend label (default : 12)
+- `gap` : The gap between the contour plot and the distribution plots (default : 0)
 """
 function Makie.plot!(fig::Union{Makie.Figure,Makie.GridPosition}, res::NMRInversions.inv_out_2D;
                      title=res.title, colormap=:viridis, contf=false, levels = 40, 
@@ -89,8 +91,10 @@ function Makie.plot!(fig::Union{Makie.Figure,Makie.GridPosition}, res::NMRInvers
         xscale = log10, yscale = log10
     )
     axtop = Axis(gr[1:2, 1:8], xscale = log10,
-                 title=title, titlesize=titlesize, titlefont=titlefont)
-    axright = Axis(gr[3:10, 9:10], yscale = log10)
+                 title=title, titlesize=titlesize, titlefont=titlefont,
+                 ygridvisible=false)
+    axright = Axis(gr[3:10, 9:10], yscale = log10,
+                   xgridvisible=false)
 
     hidedecorations!(axtop)
     hidedecorations!(axright)
@@ -185,8 +189,10 @@ function plot_diagonal(ax,x,y)
         color=:black, linewidth=1
     )
     ax.limits = ((low,high),(low,high))
-    ax.xticks = LogTicks(floor(log10(low)):ceil(log10(high)))
-    ax.yticks = LogTicks(floor(log10(low)):ceil(log10(high)))
+    if abs(log10(low)) + abs(log10(high)) <= 8
+        ax.xticks = LogTicks(floor(log10(low)):ceil(log10(high)))
+        ax.yticks = LogTicks(floor(log10(low)):ceil(log10(high)))
+    end
 end
 
 function dynamic_plots(axmain, axtop, axright, selection, polygon)

--- a/src/misc.jl
+++ b/src/misc.jl
@@ -250,9 +250,9 @@ function weighted_averages(r::inv_out_2D; silent::Bool = false)
     volumes = Vector(undef, length(r.selections))
 
     z = r.F' .* r.filter'
+    x = r.X_indir
+    y = r.X_dir
 
-    x = range(0, 1, size(z, 1))
-    y = range(0, 1, size(z, 2))
     points = [[i, j] for i in x, j in y]
     mask = zeros(size(points))
 
@@ -280,7 +280,7 @@ function weighted_averages(r::inv_out_2D; silent::Bool = false)
             println(ind_lbl[1] * " = $(round(wa_indir[i], sigdigits=4)) "*ind_lbl[2])
             println(dir_lbl[1] * " = $(round(wa_dir[i], sigdigits=4)) "*dir_lbl[2])
             if r.seq == IRCPMG
-                println("<T₁>/<T₂> = $(round(wa_dir[i], sigdigits=4)) ")
+                println("T₁/T₂ = $(round(wa_indir[i]/wa_dir[i], sigdigits=2)) ")
             end
             println("Volume = $(round(volumes[i], sigdigits=4) * 100) %")
             println()


### PR DESCRIPTION
Overhaul of the 2D gui.

Axes are now synced properly.
Changed selection points so that they reflect the actual values of relaxation times rather that a value between  0 and 1.
Limits of T1T2 plots adjusted so that diagonal is always in the middle, even if limits of direct and indirect dimensions are dissimilar.
Added "gap" option to adjust the space between contour and distribution plots.